### PR TITLE
fix: methods with no parameters and slices

### DIFF
--- a/cmd/kelpie/mock.go.tmpl
+++ b/cmd/kelpie/mock.go.tmpl
@@ -101,7 +101,7 @@ func (m *{{ $method.Name }}MethodMatcher) CreateMethodMatcher() *mocking.MethodM
 	return &m.matcher
 }
 
-func {{ $method.Name }}[{{ template "matcherTypeParams" $method.Parameters }}]({{ template "matcherParams" $method.Parameters }}) *{{ $method.Name }}MethodMatcher {
+func {{ $method.Name }}{{ if $method.Parameters }}[{{ template "matcherTypeParams" $method.Parameters }}]{{ end }}({{ template "matcherParams" $method.Parameters }}) *{{ $method.Name }}MethodMatcher {
 	result := {{ $method.Name }}MethodMatcher{
 		matcher: mocking.MethodMatcher{
 			MethodName:       "{{ $method.Name }}",

--- a/examples/mocks/accountservice/accountservice.go
+++ b/examples/mocks/accountservice/accountservice.go
@@ -61,6 +61,26 @@ func (m *Instance) DisableAccount(id uint) {
 	return
 }
 
+func (m *Instance) DisabledAccountIDs() (r0 []uint) {
+	expectation := m.mock.Call("DisabledAccountIDs", )
+	if expectation != nil {
+		if expectation.ObserveFn != nil {
+			observe := expectation.ObserveFn.(func() []uint)
+			return observe()
+		}
+
+		if expectation.PanicArg != nil {
+			panic(expectation.PanicArg)
+		}
+
+		if expectation.Returns[0] != nil {
+			r0 = expectation.Returns[0].([]uint)
+		}
+	}
+
+	return
+}
+
 func (m *Mock) Instance() *Instance {
 	return &m.instance
 }
@@ -169,6 +189,60 @@ func (a *DisableAccountMethodMatcher) Panic(arg any) *DisableAccountExpectation 
 
 func (a *DisableAccountMethodMatcher) When(observe func(id uint)) *DisableAccountExpectation {
 	return &DisableAccountExpectation{
+		expectation: mocking.Expectation{
+			MethodMatcher: &a.matcher,
+			ObserveFn:     observe,
+		},
+	}
+}
+
+type DisabledAccountIDsMethodMatcher struct {
+	matcher mocking.MethodMatcher
+}
+
+func (m *DisabledAccountIDsMethodMatcher) CreateMethodMatcher() *mocking.MethodMatcher {
+	return &m.matcher
+}
+
+func DisabledAccountIDs() *DisabledAccountIDsMethodMatcher {
+	result := DisabledAccountIDsMethodMatcher{
+		matcher: mocking.MethodMatcher{
+			MethodName:       "DisabledAccountIDs",
+			ArgumentMatchers: make([]mocking.ArgumentMatcher, 0),
+		},
+	}
+
+	return &result
+}
+
+type DisabledAccountIDsExpectation struct {
+	expectation mocking.Expectation
+}
+
+func (e *DisabledAccountIDsExpectation) CreateExpectation() *mocking.Expectation {
+	return &e.expectation
+}
+
+func (a *DisabledAccountIDsMethodMatcher) Return(r0 []uint) *DisabledAccountIDsExpectation {
+	return &DisabledAccountIDsExpectation{
+		expectation: mocking.Expectation{
+			MethodMatcher: &a.matcher,
+			Returns:       []any{r0},
+		},
+	}
+}
+
+func (a *DisabledAccountIDsMethodMatcher) Panic(arg any) *DisabledAccountIDsExpectation {
+	return &DisabledAccountIDsExpectation{
+		expectation: mocking.Expectation{
+			MethodMatcher: &a.matcher,
+			PanicArg:      arg,
+		},
+	}
+}
+
+func (a *DisabledAccountIDsMethodMatcher) When(observe func() []uint) *DisabledAccountIDsExpectation {
+	return &DisabledAccountIDsExpectation{
 		expectation: mocking.Expectation{
 			MethodMatcher: &a.matcher,
 			ObserveFn:     observe,

--- a/examples/result_test.go
+++ b/examples/result_test.go
@@ -12,6 +12,7 @@ import (
 type AccountService interface {
 	SendActivationEmail(emailAddress string) bool
 	DisableAccount(id uint)
+	DisabledAccountIDs() []uint
 }
 
 type ResultTests struct {
@@ -68,6 +69,18 @@ func (t *ResultTests) Test_CanMockMethodsWithNoReturnArgs() {
 
 	// Assert
 	t.Equal(uint(123), accountID)
+}
+
+func (t *ResultTests) Test_CanMockMethodsWithNoArgs() {
+	// Arrange
+	mock := accountservice.NewMock()
+	mock.Setup(accountservice.DisabledAccountIDs().Return([]uint{1, 2, 3}))
+
+	// Act
+	result := mock.Instance().DisabledAccountIDs()
+
+	// Assert
+	t.Equal([]uint{1, 2, 3}, result)
 }
 
 func TestResults(t *testing.T) {


### PR DESCRIPTION
- We were generating an empty generic type parameter list (`[]`) when a method had no parameters, causing a compilation error for the mocks.
- We also didn't handle slice arguments / results, which was causing a panic.