### PR TITLE
feat: use GOFILE if set

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ go install github.com/adamconnelly/kelpie/cmd/kelpie@latest
 Add a `go:generate` marker to the interface you want to mock:
 
 ```go
-//go:generate kelpie generate --source-file <filename>.go --interfaces EmailService
+//go:generate kelpie generate --interfaces EmailService
 type EmailService interface {
 	Send(sender, recipient, body string) (cost float64, err error)
 }

--- a/cmd/kelpie/main.go
+++ b/cmd/kelpie/main.go
@@ -17,7 +17,7 @@ import (
 var mockTemplate string
 
 type GenerateCmd struct {
-	SourceFile string   `short:"s" required:"" help:"The Go source file containing the interface to mock."`
+	SourceFile string   `short:"s" required:"" env:"GOFILE" help:"The Go source file containing the interface to mock."`
 	Interfaces []string `short:"i" required:"" help:"The names of the interfaces to mock."`
 	OutputDir  string   `short:"o" required:"" default:"mocks" help:"The directory to write the mock out to."`
 }

--- a/examples/argument_matching_test.go
+++ b/examples/argument_matching_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-//go:generate go run ../cmd/kelpie generate --source-file argument_matching_test.go --interfaces Maths
+//go:generate go run ../cmd/kelpie generate --interfaces Maths
 type Maths interface {
 	Add(a, b int) int
 	ParseInt(input string) (int, error)

--- a/examples/result_test.go
+++ b/examples/result_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-//go:generate go run ../cmd/kelpie generate --source-file result_test.go --interfaces AccountService
+//go:generate go run ../cmd/kelpie generate --interfaces AccountService
 type AccountService interface {
 	SendActivationEmail(emailAddress string) bool
 	DisableAccount(id uint)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -33,7 +33,7 @@ type ResultDefinition struct {
 	Type string
 }
 
-//go:generate go run ../cmd/kelpie generate --source-file parser.go --interfaces InterfaceFilter
+//go:generate go run ../cmd/kelpie generate --interfaces InterfaceFilter
 type InterfaceFilter interface {
 	// Include indicates that the specified interface should be included in the set of interfaces
 	// to generate.


### PR DESCRIPTION
I've updated the `--source-file` parameter to use the `GOFILE` env var by default. This means that the file name doesn't need to be specified in the `go:generate` commands.