### PR TITLE
feat: verify number of times method called

### DIFF
--- a/cmd/kelpie/mock.go.tmpl
+++ b/cmd/kelpie/mock.go.tmpl
@@ -118,13 +118,37 @@ func {{ $method.Name }}{{ if $method.Parameters }}[{{ template "matcherTypeParam
 	return &result
 }
 
+type {{ $method.Name }}Times struct {
+	matcher *{{ $method.Name }}MethodMatcher
+}
+
+// Times allows you to restrict the number of times a particular expectation can be matched.
+func (m *{{ $method.Name }}MethodMatcher) Times(times uint) *{{ $method.Name }}Times {
+	m.matcher.Times = &times
+
+	return &{{ $method.Name }}Times{
+		matcher: m,
+	}
+}
+
+// Once specifies that the expectation will only match once.
+func (m *{{ $method.Name }}MethodMatcher) Once() *{{ $method.Name }}Times {
+	return m.Times(1)
+}
+
+// Never specifies that the method has not been called. This is mainly useful for verification
+// rather than mocking.
+func (m *{{ $method.Name }}MethodMatcher) Never() *{{ $method.Name }}Times {
+	return m.Times(0)
+}
+
 {{- if $method.Results }}
 
 // Return returns the specified results when the method is called.
-func (a *{{ $method.Name }}MethodMatcher) Return({{ template "resultWithTypeList" $method.Results }}) *{{ $method.Name }}Action {
+func (t *{{ $method.Name }}Times) Return({{ template "resultWithTypeList" $method.Results }}) *{{ $method.Name }}Action {
 	return &{{ $method.Name }}Action{
 		expectation: mocking.Expectation{
-			MethodMatcher: &a.matcher,
+			MethodMatcher: &t.matcher.matcher,
 			Returns:       []any{ {{- template "resultList" $method.Results -}} },
 		},
 	}
@@ -132,20 +156,57 @@ func (a *{{ $method.Name }}MethodMatcher) Return({{ template "resultWithTypeList
 {{- end }}
 
 // Panic panics using the specified argument when the method is called.
-func (a *{{ $method.Name }}MethodMatcher) Panic(arg any) *{{ $method.Name }}Action {
+func (t *{{ $method.Name }}Times) Panic(arg any) *{{ $method.Name }}Action {
 	return &{{ $method.Name }}Action{
 		expectation: mocking.Expectation{
-			MethodMatcher: &a.matcher,
+			MethodMatcher: &t.matcher.matcher,
 			PanicArg:      arg,
 		},
 	}
 }
 
 // When calls the specified observe callback when the method is called.
-func (a *{{ $method.Name }}MethodMatcher) When(observe {{ template "observationCallback" $method }}) *{{ $method.Name }}Action {
+func (t *{{ $method.Name }}Times) When(observe {{ template "observationCallback" $method }}) *{{ $method.Name }}Action {
 	return &{{ $method.Name }}Action{
 		expectation: mocking.Expectation{
-			MethodMatcher: &a.matcher,
+			MethodMatcher: &t.matcher.matcher,
+			ObserveFn:     observe,
+		},
+	}
+}
+
+func (t *{{ $method.Name }}Times) CreateMethodMatcher() *mocking.MethodMatcher {
+	return &t.matcher.matcher
+}
+
+{{- if $method.Results }}
+
+// Return returns the specified results when the method is called.
+func (m *{{ $method.Name }}MethodMatcher) Return({{ template "resultWithTypeList" $method.Results }}) *{{ $method.Name }}Action {
+	return &{{ $method.Name }}Action{
+		expectation: mocking.Expectation{
+			MethodMatcher: &m.matcher,
+			Returns:       []any{ {{- template "resultList" $method.Results -}} },
+		},
+	}
+}
+{{- end }}
+
+// Panic panics using the specified argument when the method is called.
+func (m *{{ $method.Name }}MethodMatcher) Panic(arg any) *{{ $method.Name }}Action {
+	return &{{ $method.Name }}Action{
+		expectation: mocking.Expectation{
+			MethodMatcher: &m.matcher,
+			PanicArg:      arg,
+		},
+	}
+}
+
+// When calls the specified observe callback when the method is called.
+func (m *{{ $method.Name }}MethodMatcher) When(observe {{ template "observationCallback" $method }}) *{{ $method.Name }}Action {
+	return &{{ $method.Name }}Action{
+		expectation: mocking.Expectation{
+			MethodMatcher: &m.matcher,
 			ObserveFn:     observe,
 		},
 	}
@@ -157,32 +218,5 @@ type {{ $method.Name }}Action struct {
 
 func (a *{{ $method.Name }}Action) CreateExpectation() *mocking.Expectation {
 	return &a.expectation
-}
-
-// Times allows you to restrict the number of times a particular expectation can be matched.
-func (a *{{ $method.Name }}Action) Times(times int) *{{ $method.Name }}Times {
-	a.expectation.MethodMatcher.Times = &times
-
-	return &{{ $method.Name }}Times{
-		expectation: a.expectation,
-	}
-}
-
-// Once specifies that the expectation will only match once.
-func (a *{{ $method.Name }}Action) Once() *{{ $method.Name }}Times {
-	times := 1
-	a.expectation.MethodMatcher.Times = &times
-
-	return &{{ $method.Name }}Times{
-		expectation: a.expectation,
-	}
-}
-
-type {{ $method.Name }}Times struct {
-	expectation mocking.Expectation
-}
-
-func (t *{{ $method.Name }}Times) CreateExpectation() *mocking.Expectation {
-	return &t.expectation
 }
 {{- end }}

--- a/examples/mocks/accountservice/accountservice.go
+++ b/examples/mocks/accountservice/accountservice.go
@@ -110,31 +110,89 @@ func SendActivationEmail[P0 string | mocking.Matcher[string]](emailAddress P0) *
 	return &result
 }
 
+type SendActivationEmailTimes struct {
+	matcher *SendActivationEmailMethodMatcher
+}
+
+// Times allows you to restrict the number of times a particular expectation can be matched.
+func (m *SendActivationEmailMethodMatcher) Times(times uint) *SendActivationEmailTimes {
+	m.matcher.Times = &times
+
+	return &SendActivationEmailTimes{
+		matcher: m,
+	}
+}
+
+// Once specifies that the expectation will only match once.
+func (m *SendActivationEmailMethodMatcher) Once() *SendActivationEmailTimes {
+	return m.Times(1)
+}
+
+// Never specifies that the method has not been called. This is mainly useful for verification
+// rather than mocking.
+func (m *SendActivationEmailMethodMatcher) Never() *SendActivationEmailTimes {
+	return m.Times(0)
+}
+
 // Return returns the specified results when the method is called.
-func (a *SendActivationEmailMethodMatcher) Return(r0 bool) *SendActivationEmailAction {
+func (t *SendActivationEmailTimes) Return(r0 bool) *SendActivationEmailAction {
 	return &SendActivationEmailAction{
 		expectation: mocking.Expectation{
-			MethodMatcher: &a.matcher,
+			MethodMatcher: &t.matcher.matcher,
 			Returns:       []any{r0},
 		},
 	}
 }
 
 // Panic panics using the specified argument when the method is called.
-func (a *SendActivationEmailMethodMatcher) Panic(arg any) *SendActivationEmailAction {
+func (t *SendActivationEmailTimes) Panic(arg any) *SendActivationEmailAction {
 	return &SendActivationEmailAction{
 		expectation: mocking.Expectation{
-			MethodMatcher: &a.matcher,
+			MethodMatcher: &t.matcher.matcher,
 			PanicArg:      arg,
 		},
 	}
 }
 
 // When calls the specified observe callback when the method is called.
-func (a *SendActivationEmailMethodMatcher) When(observe func(emailAddress string) bool) *SendActivationEmailAction {
+func (t *SendActivationEmailTimes) When(observe func(emailAddress string) bool) *SendActivationEmailAction {
 	return &SendActivationEmailAction{
 		expectation: mocking.Expectation{
-			MethodMatcher: &a.matcher,
+			MethodMatcher: &t.matcher.matcher,
+			ObserveFn:     observe,
+		},
+	}
+}
+
+func (t *SendActivationEmailTimes) CreateMethodMatcher() *mocking.MethodMatcher {
+	return &t.matcher.matcher
+}
+
+// Return returns the specified results when the method is called.
+func (m *SendActivationEmailMethodMatcher) Return(r0 bool) *SendActivationEmailAction {
+	return &SendActivationEmailAction{
+		expectation: mocking.Expectation{
+			MethodMatcher: &m.matcher,
+			Returns:       []any{r0},
+		},
+	}
+}
+
+// Panic panics using the specified argument when the method is called.
+func (m *SendActivationEmailMethodMatcher) Panic(arg any) *SendActivationEmailAction {
+	return &SendActivationEmailAction{
+		expectation: mocking.Expectation{
+			MethodMatcher: &m.matcher,
+			PanicArg:      arg,
+		},
+	}
+}
+
+// When calls the specified observe callback when the method is called.
+func (m *SendActivationEmailMethodMatcher) When(observe func(emailAddress string) bool) *SendActivationEmailAction {
+	return &SendActivationEmailAction{
+		expectation: mocking.Expectation{
+			MethodMatcher: &m.matcher,
 			ObserveFn:     observe,
 		},
 	}
@@ -146,33 +204,6 @@ type SendActivationEmailAction struct {
 
 func (a *SendActivationEmailAction) CreateExpectation() *mocking.Expectation {
 	return &a.expectation
-}
-
-// Times allows you to restrict the number of times a particular expectation can be matched.
-func (a *SendActivationEmailAction) Times(times int) *SendActivationEmailTimes {
-	a.expectation.MethodMatcher.Times = &times
-
-	return &SendActivationEmailTimes{
-		expectation: a.expectation,
-	}
-}
-
-// Once specifies that the expectation will only match once.
-func (a *SendActivationEmailAction) Once() *SendActivationEmailTimes {
-	times := 1
-	a.expectation.MethodMatcher.Times = &times
-
-	return &SendActivationEmailTimes{
-		expectation: a.expectation,
-	}
-}
-
-type SendActivationEmailTimes struct {
-	expectation mocking.Expectation
-}
-
-func (t *SendActivationEmailTimes) CreateExpectation() *mocking.Expectation {
-	return &t.expectation
 }
 
 type DisableAccountMethodMatcher struct {
@@ -200,21 +231,69 @@ func DisableAccount[P0 uint | mocking.Matcher[uint]](id P0) *DisableAccountMetho
 	return &result
 }
 
+type DisableAccountTimes struct {
+	matcher *DisableAccountMethodMatcher
+}
+
+// Times allows you to restrict the number of times a particular expectation can be matched.
+func (m *DisableAccountMethodMatcher) Times(times uint) *DisableAccountTimes {
+	m.matcher.Times = &times
+
+	return &DisableAccountTimes{
+		matcher: m,
+	}
+}
+
+// Once specifies that the expectation will only match once.
+func (m *DisableAccountMethodMatcher) Once() *DisableAccountTimes {
+	return m.Times(1)
+}
+
+// Never specifies that the method has not been called. This is mainly useful for verification
+// rather than mocking.
+func (m *DisableAccountMethodMatcher) Never() *DisableAccountTimes {
+	return m.Times(0)
+}
+
 // Panic panics using the specified argument when the method is called.
-func (a *DisableAccountMethodMatcher) Panic(arg any) *DisableAccountAction {
+func (t *DisableAccountTimes) Panic(arg any) *DisableAccountAction {
 	return &DisableAccountAction{
 		expectation: mocking.Expectation{
-			MethodMatcher: &a.matcher,
+			MethodMatcher: &t.matcher.matcher,
 			PanicArg:      arg,
 		},
 	}
 }
 
 // When calls the specified observe callback when the method is called.
-func (a *DisableAccountMethodMatcher) When(observe func(id uint)) *DisableAccountAction {
+func (t *DisableAccountTimes) When(observe func(id uint)) *DisableAccountAction {
 	return &DisableAccountAction{
 		expectation: mocking.Expectation{
-			MethodMatcher: &a.matcher,
+			MethodMatcher: &t.matcher.matcher,
+			ObserveFn:     observe,
+		},
+	}
+}
+
+func (t *DisableAccountTimes) CreateMethodMatcher() *mocking.MethodMatcher {
+	return &t.matcher.matcher
+}
+
+// Panic panics using the specified argument when the method is called.
+func (m *DisableAccountMethodMatcher) Panic(arg any) *DisableAccountAction {
+	return &DisableAccountAction{
+		expectation: mocking.Expectation{
+			MethodMatcher: &m.matcher,
+			PanicArg:      arg,
+		},
+	}
+}
+
+// When calls the specified observe callback when the method is called.
+func (m *DisableAccountMethodMatcher) When(observe func(id uint)) *DisableAccountAction {
+	return &DisableAccountAction{
+		expectation: mocking.Expectation{
+			MethodMatcher: &m.matcher,
 			ObserveFn:     observe,
 		},
 	}
@@ -226,33 +305,6 @@ type DisableAccountAction struct {
 
 func (a *DisableAccountAction) CreateExpectation() *mocking.Expectation {
 	return &a.expectation
-}
-
-// Times allows you to restrict the number of times a particular expectation can be matched.
-func (a *DisableAccountAction) Times(times int) *DisableAccountTimes {
-	a.expectation.MethodMatcher.Times = &times
-
-	return &DisableAccountTimes{
-		expectation: a.expectation,
-	}
-}
-
-// Once specifies that the expectation will only match once.
-func (a *DisableAccountAction) Once() *DisableAccountTimes {
-	times := 1
-	a.expectation.MethodMatcher.Times = &times
-
-	return &DisableAccountTimes{
-		expectation: a.expectation,
-	}
-}
-
-type DisableAccountTimes struct {
-	expectation mocking.Expectation
-}
-
-func (t *DisableAccountTimes) CreateExpectation() *mocking.Expectation {
-	return &t.expectation
 }
 
 type DisabledAccountIDsMethodMatcher struct {
@@ -274,31 +326,89 @@ func DisabledAccountIDs() *DisabledAccountIDsMethodMatcher {
 	return &result
 }
 
+type DisabledAccountIDsTimes struct {
+	matcher *DisabledAccountIDsMethodMatcher
+}
+
+// Times allows you to restrict the number of times a particular expectation can be matched.
+func (m *DisabledAccountIDsMethodMatcher) Times(times uint) *DisabledAccountIDsTimes {
+	m.matcher.Times = &times
+
+	return &DisabledAccountIDsTimes{
+		matcher: m,
+	}
+}
+
+// Once specifies that the expectation will only match once.
+func (m *DisabledAccountIDsMethodMatcher) Once() *DisabledAccountIDsTimes {
+	return m.Times(1)
+}
+
+// Never specifies that the method has not been called. This is mainly useful for verification
+// rather than mocking.
+func (m *DisabledAccountIDsMethodMatcher) Never() *DisabledAccountIDsTimes {
+	return m.Times(0)
+}
+
 // Return returns the specified results when the method is called.
-func (a *DisabledAccountIDsMethodMatcher) Return(r0 []uint) *DisabledAccountIDsAction {
+func (t *DisabledAccountIDsTimes) Return(r0 []uint) *DisabledAccountIDsAction {
 	return &DisabledAccountIDsAction{
 		expectation: mocking.Expectation{
-			MethodMatcher: &a.matcher,
+			MethodMatcher: &t.matcher.matcher,
 			Returns:       []any{r0},
 		},
 	}
 }
 
 // Panic panics using the specified argument when the method is called.
-func (a *DisabledAccountIDsMethodMatcher) Panic(arg any) *DisabledAccountIDsAction {
+func (t *DisabledAccountIDsTimes) Panic(arg any) *DisabledAccountIDsAction {
 	return &DisabledAccountIDsAction{
 		expectation: mocking.Expectation{
-			MethodMatcher: &a.matcher,
+			MethodMatcher: &t.matcher.matcher,
 			PanicArg:      arg,
 		},
 	}
 }
 
 // When calls the specified observe callback when the method is called.
-func (a *DisabledAccountIDsMethodMatcher) When(observe func() []uint) *DisabledAccountIDsAction {
+func (t *DisabledAccountIDsTimes) When(observe func() []uint) *DisabledAccountIDsAction {
 	return &DisabledAccountIDsAction{
 		expectation: mocking.Expectation{
-			MethodMatcher: &a.matcher,
+			MethodMatcher: &t.matcher.matcher,
+			ObserveFn:     observe,
+		},
+	}
+}
+
+func (t *DisabledAccountIDsTimes) CreateMethodMatcher() *mocking.MethodMatcher {
+	return &t.matcher.matcher
+}
+
+// Return returns the specified results when the method is called.
+func (m *DisabledAccountIDsMethodMatcher) Return(r0 []uint) *DisabledAccountIDsAction {
+	return &DisabledAccountIDsAction{
+		expectation: mocking.Expectation{
+			MethodMatcher: &m.matcher,
+			Returns:       []any{r0},
+		},
+	}
+}
+
+// Panic panics using the specified argument when the method is called.
+func (m *DisabledAccountIDsMethodMatcher) Panic(arg any) *DisabledAccountIDsAction {
+	return &DisabledAccountIDsAction{
+		expectation: mocking.Expectation{
+			MethodMatcher: &m.matcher,
+			PanicArg:      arg,
+		},
+	}
+}
+
+// When calls the specified observe callback when the method is called.
+func (m *DisabledAccountIDsMethodMatcher) When(observe func() []uint) *DisabledAccountIDsAction {
+	return &DisabledAccountIDsAction{
+		expectation: mocking.Expectation{
+			MethodMatcher: &m.matcher,
 			ObserveFn:     observe,
 		},
 	}
@@ -310,31 +420,4 @@ type DisabledAccountIDsAction struct {
 
 func (a *DisabledAccountIDsAction) CreateExpectation() *mocking.Expectation {
 	return &a.expectation
-}
-
-// Times allows you to restrict the number of times a particular expectation can be matched.
-func (a *DisabledAccountIDsAction) Times(times int) *DisabledAccountIDsTimes {
-	a.expectation.MethodMatcher.Times = &times
-
-	return &DisabledAccountIDsTimes{
-		expectation: a.expectation,
-	}
-}
-
-// Once specifies that the expectation will only match once.
-func (a *DisabledAccountIDsAction) Once() *DisabledAccountIDsTimes {
-	times := 1
-	a.expectation.MethodMatcher.Times = &times
-
-	return &DisabledAccountIDsTimes{
-		expectation: a.expectation,
-	}
-}
-
-type DisabledAccountIDsTimes struct {
-	expectation mocking.Expectation
-}
-
-func (t *DisabledAccountIDsTimes) CreateExpectation() *mocking.Expectation {
-	return &t.expectation
 }

--- a/examples/mocks/alarmservice/alarmservice.go
+++ b/examples/mocks/alarmservice/alarmservice.go
@@ -73,31 +73,89 @@ func CreateAlarm[P0 string | mocking.Matcher[string]](name P0) *CreateAlarmMetho
 	return &result
 }
 
+type CreateAlarmTimes struct {
+	matcher *CreateAlarmMethodMatcher
+}
+
+// Times allows you to restrict the number of times a particular expectation can be matched.
+func (m *CreateAlarmMethodMatcher) Times(times uint) *CreateAlarmTimes {
+	m.matcher.Times = &times
+
+	return &CreateAlarmTimes{
+		matcher: m,
+	}
+}
+
+// Once specifies that the expectation will only match once.
+func (m *CreateAlarmMethodMatcher) Once() *CreateAlarmTimes {
+	return m.Times(1)
+}
+
+// Never specifies that the method has not been called. This is mainly useful for verification
+// rather than mocking.
+func (m *CreateAlarmMethodMatcher) Never() *CreateAlarmTimes {
+	return m.Times(0)
+}
+
 // Return returns the specified results when the method is called.
-func (a *CreateAlarmMethodMatcher) Return(r0 error) *CreateAlarmAction {
+func (t *CreateAlarmTimes) Return(r0 error) *CreateAlarmAction {
 	return &CreateAlarmAction{
 		expectation: mocking.Expectation{
-			MethodMatcher: &a.matcher,
+			MethodMatcher: &t.matcher.matcher,
 			Returns:       []any{r0},
 		},
 	}
 }
 
 // Panic panics using the specified argument when the method is called.
-func (a *CreateAlarmMethodMatcher) Panic(arg any) *CreateAlarmAction {
+func (t *CreateAlarmTimes) Panic(arg any) *CreateAlarmAction {
 	return &CreateAlarmAction{
 		expectation: mocking.Expectation{
-			MethodMatcher: &a.matcher,
+			MethodMatcher: &t.matcher.matcher,
 			PanicArg:      arg,
 		},
 	}
 }
 
 // When calls the specified observe callback when the method is called.
-func (a *CreateAlarmMethodMatcher) When(observe func(name string) error) *CreateAlarmAction {
+func (t *CreateAlarmTimes) When(observe func(name string) error) *CreateAlarmAction {
 	return &CreateAlarmAction{
 		expectation: mocking.Expectation{
-			MethodMatcher: &a.matcher,
+			MethodMatcher: &t.matcher.matcher,
+			ObserveFn:     observe,
+		},
+	}
+}
+
+func (t *CreateAlarmTimes) CreateMethodMatcher() *mocking.MethodMatcher {
+	return &t.matcher.matcher
+}
+
+// Return returns the specified results when the method is called.
+func (m *CreateAlarmMethodMatcher) Return(r0 error) *CreateAlarmAction {
+	return &CreateAlarmAction{
+		expectation: mocking.Expectation{
+			MethodMatcher: &m.matcher,
+			Returns:       []any{r0},
+		},
+	}
+}
+
+// Panic panics using the specified argument when the method is called.
+func (m *CreateAlarmMethodMatcher) Panic(arg any) *CreateAlarmAction {
+	return &CreateAlarmAction{
+		expectation: mocking.Expectation{
+			MethodMatcher: &m.matcher,
+			PanicArg:      arg,
+		},
+	}
+}
+
+// When calls the specified observe callback when the method is called.
+func (m *CreateAlarmMethodMatcher) When(observe func(name string) error) *CreateAlarmAction {
+	return &CreateAlarmAction{
+		expectation: mocking.Expectation{
+			MethodMatcher: &m.matcher,
 			ObserveFn:     observe,
 		},
 	}
@@ -109,31 +167,4 @@ type CreateAlarmAction struct {
 
 func (a *CreateAlarmAction) CreateExpectation() *mocking.Expectation {
 	return &a.expectation
-}
-
-// Times allows you to restrict the number of times a particular expectation can be matched.
-func (a *CreateAlarmAction) Times(times int) *CreateAlarmTimes {
-	a.expectation.MethodMatcher.Times = &times
-
-	return &CreateAlarmTimes{
-		expectation: a.expectation,
-	}
-}
-
-// Once specifies that the expectation will only match once.
-func (a *CreateAlarmAction) Once() *CreateAlarmTimes {
-	times := 1
-	a.expectation.MethodMatcher.Times = &times
-
-	return &CreateAlarmTimes{
-		expectation: a.expectation,
-	}
-}
-
-type CreateAlarmTimes struct {
-	expectation mocking.Expectation
-}
-
-func (t *CreateAlarmTimes) CreateExpectation() *mocking.Expectation {
-	return &t.expectation
 }

--- a/examples/mocks/maths/maths.go
+++ b/examples/mocks/maths/maths.go
@@ -103,31 +103,89 @@ func Add[P0 int | mocking.Matcher[int], P1 int | mocking.Matcher[int]](a P0, b P
 	return &result
 }
 
+type AddTimes struct {
+	matcher *AddMethodMatcher
+}
+
+// Times allows you to restrict the number of times a particular expectation can be matched.
+func (m *AddMethodMatcher) Times(times uint) *AddTimes {
+	m.matcher.Times = &times
+
+	return &AddTimes{
+		matcher: m,
+	}
+}
+
+// Once specifies that the expectation will only match once.
+func (m *AddMethodMatcher) Once() *AddTimes {
+	return m.Times(1)
+}
+
+// Never specifies that the method has not been called. This is mainly useful for verification
+// rather than mocking.
+func (m *AddMethodMatcher) Never() *AddTimes {
+	return m.Times(0)
+}
+
 // Return returns the specified results when the method is called.
-func (a *AddMethodMatcher) Return(r0 int) *AddAction {
+func (t *AddTimes) Return(r0 int) *AddAction {
 	return &AddAction{
 		expectation: mocking.Expectation{
-			MethodMatcher: &a.matcher,
+			MethodMatcher: &t.matcher.matcher,
 			Returns:       []any{r0},
 		},
 	}
 }
 
 // Panic panics using the specified argument when the method is called.
-func (a *AddMethodMatcher) Panic(arg any) *AddAction {
+func (t *AddTimes) Panic(arg any) *AddAction {
 	return &AddAction{
 		expectation: mocking.Expectation{
-			MethodMatcher: &a.matcher,
+			MethodMatcher: &t.matcher.matcher,
 			PanicArg:      arg,
 		},
 	}
 }
 
 // When calls the specified observe callback when the method is called.
-func (a *AddMethodMatcher) When(observe func(a int, b int) int) *AddAction {
+func (t *AddTimes) When(observe func(a int, b int) int) *AddAction {
 	return &AddAction{
 		expectation: mocking.Expectation{
-			MethodMatcher: &a.matcher,
+			MethodMatcher: &t.matcher.matcher,
+			ObserveFn:     observe,
+		},
+	}
+}
+
+func (t *AddTimes) CreateMethodMatcher() *mocking.MethodMatcher {
+	return &t.matcher.matcher
+}
+
+// Return returns the specified results when the method is called.
+func (m *AddMethodMatcher) Return(r0 int) *AddAction {
+	return &AddAction{
+		expectation: mocking.Expectation{
+			MethodMatcher: &m.matcher,
+			Returns:       []any{r0},
+		},
+	}
+}
+
+// Panic panics using the specified argument when the method is called.
+func (m *AddMethodMatcher) Panic(arg any) *AddAction {
+	return &AddAction{
+		expectation: mocking.Expectation{
+			MethodMatcher: &m.matcher,
+			PanicArg:      arg,
+		},
+	}
+}
+
+// When calls the specified observe callback when the method is called.
+func (m *AddMethodMatcher) When(observe func(a int, b int) int) *AddAction {
+	return &AddAction{
+		expectation: mocking.Expectation{
+			MethodMatcher: &m.matcher,
 			ObserveFn:     observe,
 		},
 	}
@@ -139,33 +197,6 @@ type AddAction struct {
 
 func (a *AddAction) CreateExpectation() *mocking.Expectation {
 	return &a.expectation
-}
-
-// Times allows you to restrict the number of times a particular expectation can be matched.
-func (a *AddAction) Times(times int) *AddTimes {
-	a.expectation.MethodMatcher.Times = &times
-
-	return &AddTimes{
-		expectation: a.expectation,
-	}
-}
-
-// Once specifies that the expectation will only match once.
-func (a *AddAction) Once() *AddTimes {
-	times := 1
-	a.expectation.MethodMatcher.Times = &times
-
-	return &AddTimes{
-		expectation: a.expectation,
-	}
-}
-
-type AddTimes struct {
-	expectation mocking.Expectation
-}
-
-func (t *AddTimes) CreateExpectation() *mocking.Expectation {
-	return &t.expectation
 }
 
 type ParseIntMethodMatcher struct {
@@ -193,31 +224,89 @@ func ParseInt[P0 string | mocking.Matcher[string]](input P0) *ParseIntMethodMatc
 	return &result
 }
 
+type ParseIntTimes struct {
+	matcher *ParseIntMethodMatcher
+}
+
+// Times allows you to restrict the number of times a particular expectation can be matched.
+func (m *ParseIntMethodMatcher) Times(times uint) *ParseIntTimes {
+	m.matcher.Times = &times
+
+	return &ParseIntTimes{
+		matcher: m,
+	}
+}
+
+// Once specifies that the expectation will only match once.
+func (m *ParseIntMethodMatcher) Once() *ParseIntTimes {
+	return m.Times(1)
+}
+
+// Never specifies that the method has not been called. This is mainly useful for verification
+// rather than mocking.
+func (m *ParseIntMethodMatcher) Never() *ParseIntTimes {
+	return m.Times(0)
+}
+
 // Return returns the specified results when the method is called.
-func (a *ParseIntMethodMatcher) Return(r0 int, r1 error) *ParseIntAction {
+func (t *ParseIntTimes) Return(r0 int, r1 error) *ParseIntAction {
 	return &ParseIntAction{
 		expectation: mocking.Expectation{
-			MethodMatcher: &a.matcher,
+			MethodMatcher: &t.matcher.matcher,
 			Returns:       []any{r0, r1},
 		},
 	}
 }
 
 // Panic panics using the specified argument when the method is called.
-func (a *ParseIntMethodMatcher) Panic(arg any) *ParseIntAction {
+func (t *ParseIntTimes) Panic(arg any) *ParseIntAction {
 	return &ParseIntAction{
 		expectation: mocking.Expectation{
-			MethodMatcher: &a.matcher,
+			MethodMatcher: &t.matcher.matcher,
 			PanicArg:      arg,
 		},
 	}
 }
 
 // When calls the specified observe callback when the method is called.
-func (a *ParseIntMethodMatcher) When(observe func(input string) (int, error)) *ParseIntAction {
+func (t *ParseIntTimes) When(observe func(input string) (int, error)) *ParseIntAction {
 	return &ParseIntAction{
 		expectation: mocking.Expectation{
-			MethodMatcher: &a.matcher,
+			MethodMatcher: &t.matcher.matcher,
+			ObserveFn:     observe,
+		},
+	}
+}
+
+func (t *ParseIntTimes) CreateMethodMatcher() *mocking.MethodMatcher {
+	return &t.matcher.matcher
+}
+
+// Return returns the specified results when the method is called.
+func (m *ParseIntMethodMatcher) Return(r0 int, r1 error) *ParseIntAction {
+	return &ParseIntAction{
+		expectation: mocking.Expectation{
+			MethodMatcher: &m.matcher,
+			Returns:       []any{r0, r1},
+		},
+	}
+}
+
+// Panic panics using the specified argument when the method is called.
+func (m *ParseIntMethodMatcher) Panic(arg any) *ParseIntAction {
+	return &ParseIntAction{
+		expectation: mocking.Expectation{
+			MethodMatcher: &m.matcher,
+			PanicArg:      arg,
+		},
+	}
+}
+
+// When calls the specified observe callback when the method is called.
+func (m *ParseIntMethodMatcher) When(observe func(input string) (int, error)) *ParseIntAction {
+	return &ParseIntAction{
+		expectation: mocking.Expectation{
+			MethodMatcher: &m.matcher,
 			ObserveFn:     observe,
 		},
 	}
@@ -229,31 +318,4 @@ type ParseIntAction struct {
 
 func (a *ParseIntAction) CreateExpectation() *mocking.Expectation {
 	return &a.expectation
-}
-
-// Times allows you to restrict the number of times a particular expectation can be matched.
-func (a *ParseIntAction) Times(times int) *ParseIntTimes {
-	a.expectation.MethodMatcher.Times = &times
-
-	return &ParseIntTimes{
-		expectation: a.expectation,
-	}
-}
-
-// Once specifies that the expectation will only match once.
-func (a *ParseIntAction) Once() *ParseIntTimes {
-	times := 1
-	a.expectation.MethodMatcher.Times = &times
-
-	return &ParseIntTimes{
-		expectation: a.expectation,
-	}
-}
-
-type ParseIntTimes struct {
-	expectation mocking.Expectation
-}
-
-func (t *ParseIntTimes) CreateExpectation() *mocking.Expectation {
-	return &t.expectation
 }

--- a/examples/times_test.go
+++ b/examples/times_test.go
@@ -38,7 +38,7 @@ func (t *TimesTests) Test_Mocking_DefaultsToMatchingUnlimitedTimes() {
 func (t *TimesTests) Test_Mocking_CanMatchSpecificTimes() {
 	// Arrange
 	mock := alarmservice.NewMock()
-	mock.Setup(alarmservice.CreateAlarm(kelpie.Any[string]()).Return(errors.New("Cannot create alarm :(")).Times(2))
+	mock.Setup(alarmservice.CreateAlarm(kelpie.Any[string]()).Times(2).Return(errors.New("Cannot create alarm :(")))
 
 	// Act
 	result1 := mock.Instance().CreateAlarm("Fire alarm")
@@ -54,7 +54,7 @@ func (t *TimesTests) Test_Mocking_CanMatchSpecificTimes() {
 func (t *TimesTests) Test_Mocking_CanMatchOnce() {
 	// Arrange
 	mock := alarmservice.NewMock()
-	mock.Setup(alarmservice.CreateAlarm(kelpie.Any[string]()).Return(errors.New("Cannot create alarm :(")).Once())
+	mock.Setup(alarmservice.CreateAlarm(kelpie.Any[string]()).Once().Return(errors.New("Cannot create alarm :(")))
 
 	// Act
 	result1 := mock.Instance().CreateAlarm("Fire alarm")
@@ -67,7 +67,56 @@ func (t *TimesTests) Test_Mocking_CanMatchOnce() {
 	t.NoError(result3)
 }
 
-// TODO: add tests for verification after refactoring setup vs verifying
+func (t *TimesTests) Test_Mocking_CanMatchZeroTimes() {
+	// Arrange
+	mock := alarmservice.NewMock()
+	mock.Setup(alarmservice.CreateAlarm(kelpie.Any[string]()).Times(0).Return(errors.New("Cannot create alarm :(")))
+
+	// Act
+	result1 := mock.Instance().CreateAlarm("Fire alarm")
+
+	// Assert
+	t.NoError(result1)
+}
+
+func (t *TimesTests) Test_Mocking_CanMatchNever() {
+	// Arrange
+	mock := alarmservice.NewMock()
+	mock.Setup(alarmservice.CreateAlarm(kelpie.Any[string]()).Never().Return(errors.New("Cannot create alarm :(")))
+
+	// Act
+	result1 := mock.Instance().CreateAlarm("Fire alarm")
+
+	// Assert
+	t.NoError(result1)
+}
+
+func (t *TimesTests) Test_Verification_CanMatchSpecificTimes() {
+	// Arrange
+	mock := alarmservice.NewMock()
+
+	// Act
+	mock.Instance().CreateAlarm("Alarm 1")
+	mock.Instance().CreateAlarm("Alarm 2")
+
+	// Assert
+	t.True(mock.Called(alarmservice.CreateAlarm(kelpie.Any[string]()).Times(2)))
+	t.True(mock.Called(alarmservice.CreateAlarm("Alarm 1").Once()))
+	t.False(mock.Called(alarmservice.CreateAlarm("Alarm 2").Times(2)))
+}
+
+func (t *TimesTests) Test_Verification_Never() {
+	// Arrange
+	mock := alarmservice.NewMock()
+
+	// Act
+	mock.Instance().CreateAlarm("Alarm 1")
+	mock.Instance().CreateAlarm("Alarm 2")
+
+	// Assert
+	t.False(mock.Called(alarmservice.CreateAlarm(kelpie.Any[string]()).Never()))
+	t.True(mock.Called(alarmservice.CreateAlarm("Alarm 3").Never()))
+}
 
 func TestTimes(t *testing.T) {
 	suite.Run(t, new(TimesTests))

--- a/mocking/mock.go
+++ b/mocking/mock.go
@@ -9,7 +9,7 @@ import (
 type MethodMatcher struct {
 	MethodName       string
 	ArgumentMatchers []ArgumentMatcher
-	Times            *int
+	Times            *uint
 }
 
 type Expectation struct {
@@ -51,7 +51,7 @@ func (m *Mock) Call(methodName string, args ...any) *Expectation {
 			calls := slices.All(m.MethodCalls, func(methodCall *MethodCall) bool {
 				return methodMatchesExpectation(methodMatcher, methodCall.MethodName, methodCall.Args...)
 			})
-			if len(calls) <= *expectation.MethodMatcher.Times {
+			if uint(len(calls)) <= *expectation.MethodMatcher.Times {
 				return expectation
 			}
 		} else if methodMatchesExpectation(methodMatcher, methodName, args...) {
@@ -70,7 +70,7 @@ func (m *Mock) Called(creator MethodMatcherCreator) bool {
 			return methodMatchesExpectation(methodMatcher, call.MethodName, call.Args...)
 		})
 
-		return len(matches) == *methodMatcher.Times
+		return uint(len(matches)) == *methodMatcher.Times
 	}
 
 	return slices.Contains(m.MethodCalls, func(call *MethodCall) bool {

--- a/mocking/mock_test.go
+++ b/mocking/mock_test.go
@@ -199,7 +199,7 @@ func (t *MockTests) TestCall_MatchesExpectationSpecifiedNumberOfTimes() {
 		MethodMatcher: &mocking.MethodMatcher{
 			MethodName:       "IncreaseVelocity",
 			ArgumentMatchers: []mocking.ArgumentMatcher{kelpie.ExactMatch[int](20)},
-			Times:            nullable.OfValue(3),
+			Times:            nullable.OfValue[uint](3),
 		},
 		Returns: []any{errors.New("nope")},
 	}))
@@ -301,7 +301,7 @@ func (t *MockTests) TestCalled_ReturnsFalseIfMethodNotCalledEnoughTimes() {
 					kelpie.Any[int](),
 					kelpie.Any[int](),
 				},
-				Times: nullable.OfValue(4),
+				Times: nullable.OfValue[uint](4),
 			}))
 
 	// Assert
@@ -324,7 +324,7 @@ func (t *MockTests) TestCalled_ReturnsTrueIfMethodCalledEnoughTimes() {
 					kelpie.Any[int](),
 					kelpie.Any[int](),
 				},
-				Times: nullable.OfValue(3),
+				Times: nullable.OfValue[uint](3),
 			}))
 
 	// Assert


### PR DESCRIPTION
Added the ability to verify the number of times a method has been called. To do this I swapped the order of `Times()` vs the action methods so that you don't have to specify a result when trying to verify a method has been called.