### PR TITLE
refactor: switch to packages.Load

### DIFF
--- a/cmd/kelpie/main.go
+++ b/cmd/kelpie/main.go
@@ -21,21 +21,17 @@ var mockTemplate string
 
 type generateCmd struct {
 	SourceFile string   `short:"s" required:"" env:"GOFILE" help:"The Go source file containing the interface to mock."`
+	Package    string   `short:"p" required:"" env:"GOPACKAGE" help:"The Go package containing the interface to mock."`
 	Interfaces []string `short:"i" required:"" help:"The names of the interfaces to mock."`
 	OutputDir  string   `short:"o" required:"" default:"mocks" help:"The directory to write the mock out to."`
 }
 
 func (g *generateCmd) Run() error {
-	file, err := os.Open(g.SourceFile)
-	if err != nil {
-		return errors.Wrap(err, "could not open file for parsing")
-	}
-
 	filter := parser.IncludingInterfaceFilter{
 		InterfacesToInclude: g.Interfaces,
 	}
 
-	mockedInterfaces, err := parser.Parse(file, &filter)
+	mockedInterfaces, err := parser.Parse(g.Package, filepath.Dir(g.SourceFile), &filter)
 	if err != nil {
 		return errors.Wrap(err, "could not parse file")
 	}

--- a/examples/mocks/maths/maths.go
+++ b/examples/mocks/maths/maths.go
@@ -47,18 +47,18 @@ func (m *Instance) Add(a int, b int) (r0 int) {
 
 // ParseInt interprets a string s in the given base (0, 2 to 36) and bit size (0 to 64)
 // and returns the corresponding value i.
-// 
+//
 // The string may begin with a leading sign: "+" or "-".
-// 
+//
 // If the base argument is 0, the true base is implied by the string's prefix following
 // the sign (if present): 2 for "0b", 8 for "0" or "0o", 16 for "0x", and 10 otherwise.
 // Also, for argument base 0 only, underscore characters are permitted as defined by the
 // Go syntax for integer literals.
-// 
+//
 // The bitSize argument specifies the integer type that the result must fit into. Bit
 // sizes 0, 8, 16, 32, and 64 correspond to int, int8, int16, int32, and int64. If bitSize
 // is below 0 or above 64, an error is returned.
-// 
+//
 // The errors that ParseInt returns have concrete type *NumError and include err.Num = s.
 // If s is empty or contains invalid digits, err.Err = ErrSyntax and the returned value is
 // 0; if the value corresponding to s cannot be represented by a signed integer of the given
@@ -230,18 +230,18 @@ func (m *ParseIntMethodMatcher) CreateMethodMatcher() *mocking.MethodMatcher {
 
 // ParseInt interprets a string s in the given base (0, 2 to 36) and bit size (0 to 64)
 // and returns the corresponding value i.
-// 
+//
 // The string may begin with a leading sign: "+" or "-".
-// 
+//
 // If the base argument is 0, the true base is implied by the string's prefix following
 // the sign (if present): 2 for "0b", 8 for "0" or "0o", 16 for "0x", and 10 otherwise.
 // Also, for argument base 0 only, underscore characters are permitted as defined by the
 // Go syntax for integer literals.
-// 
+//
 // The bitSize argument specifies the integer type that the result must fit into. Bit
 // sizes 0, 8, 16, 32, and 64 correspond to int, int8, int16, int32, and int64. If bitSize
 // is below 0 or above 64, an error is returned.
-// 
+//
 // The errors that ParseInt returns have concrete type *NumError and include err.Num = s.
 // If s is empty or contains invalid digits, err.Err = ErrSyntax and the returned value is
 // 0; if the value corresponding to s cannot be represented by a signed integer of the given

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,17 @@ module github.com/adamconnelly/kelpie
 go 1.20
 
 require (
+	github.com/pkg/errors v0.9.1
+	golang.org/x/tools v0.21.0
+)
+
+require (
 	github.com/alecthomas/kong v0.8.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.1 // indirect
 	github.com/stretchr/testify v1.8.4 // indirect
+	golang.org/x/mod v0.17.0 // indirect
+	golang.org/x/sync v0.7.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,12 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+golang.org/x/mod v0.17.0 h1:zY54UmvipHiNd+pm+m0x9KhZ9hl1/7QNMyxXbc6ICqA=
+golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
+golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/tools v0.21.0 h1:qc0xYgIbsSDt9EyWz05J5wfa7LOVW0YTLOXrqdLAWIw=
+golang.org/x/tools v0.21.0/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
Switching to using `packages.Load` to parse the code. This is in preparation of adding support for things like external modules and dot imports.