### PR TITLE
fix: generate mocks in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ go install github.com/adamconnelly/kelpie/cmd/kelpie@latest
 Add a `go:generate` marker to the interface you want to mock:
 
 ```go
-//go:generate kelpie generate --interfaces EmailService
+//go:generate kelpie generate --package github.com/someorg/some/package --interfaces EmailService
 type EmailService interface {
 	Send(sender, recipient, body string) (cost float64, err error)
 }

--- a/cmd/kelpie/main.go
+++ b/cmd/kelpie/main.go
@@ -20,8 +20,7 @@ import (
 var mockTemplate string
 
 type generateCmd struct {
-	SourceFile string   `short:"s" required:"" env:"GOFILE" help:"The Go source file containing the interface to mock."`
-	Package    string   `short:"p" required:"" env:"GOPACKAGE" help:"The Go package containing the interface to mock."`
+	Package    string   `short:"p" required:"" help:"The Go package containing the interface to mock."`
 	Interfaces []string `short:"i" required:"" help:"The names of the interfaces to mock."`
 	OutputDir  string   `short:"o" required:"" default:"mocks" help:"The directory to write the mock out to."`
 }
@@ -31,7 +30,12 @@ func (g *generateCmd) Run() error {
 		InterfacesToInclude: g.Interfaces,
 	}
 
-	mockedInterfaces, err := parser.Parse(g.Package, filepath.Dir(g.SourceFile), &filter)
+	cwd, err := os.Getwd()
+	if err != nil {
+		return errors.Wrap(err, "could not get current working directory")
+	}
+
+	mockedInterfaces, err := parser.Parse(g.Package, cwd, &filter)
 	if err != nil {
 		return errors.Wrap(err, "could not parse file")
 	}

--- a/examples/argument_matching_test.go
+++ b/examples/argument_matching_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-//go:generate go run ../cmd/kelpie generate --interfaces Maths
+//go:generate go run ../cmd/kelpie generate --package github.com/adamconnelly/kelpie/examples --interfaces Maths
 type Maths interface {
 	// Add adds a and b together and returns the result.
 	Add(a, b int) int
@@ -37,7 +37,7 @@ type Maths interface {
 	ParseInt(input string) (int, error)
 }
 
-//go:generate go run ../cmd/kelpie generate --interfaces Sender
+//go:generate go run ../cmd/kelpie generate --package github.com/adamconnelly/kelpie/examples --interfaces Sender
 type Sender interface {
 	SendMessage(title *string, message string) error
 }

--- a/examples/called_test.go
+++ b/examples/called_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/adamconnelly/kelpie/examples/mocks/registrationservice"
 )
 
-//go:generate go run ../cmd/kelpie generate --interfaces RegistrationService
+//go:generate go run ../cmd/kelpie generate --package github.com/adamconnelly/kelpie/examples --interfaces RegistrationService
 type RegistrationService interface {
 	// Register registers the item with the specified name.
 	Register(name string) error

--- a/examples/result_test.go
+++ b/examples/result_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-//go:generate go run ../cmd/kelpie generate --interfaces AccountService
+//go:generate go run ../cmd/kelpie generate --package github.com/adamconnelly/kelpie/examples --interfaces AccountService
 type AccountService interface {
 	SendActivationEmail(emailAddress string) bool
 	DisableAccount(id uint)

--- a/examples/times_test.go
+++ b/examples/times_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/adamconnelly/kelpie/examples/mocks/alarmservice"
 )
 
-//go:generate go run ../cmd/kelpie generate --interfaces AlarmService
+//go:generate go run ../cmd/kelpie generate --package github.com/adamconnelly/kelpie/examples --interfaces AlarmService
 type AlarmService interface {
 	CreateAlarm(name string) error
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -58,7 +58,7 @@ type ResultDefinition struct {
 	Type string
 }
 
-//go:generate go run ../cmd/kelpie generate --interfaces InterfaceFilter
+//go:generate go run ../cmd/kelpie generate --package github.com/adamconnelly/kelpie/parser --interfaces InterfaceFilter
 
 // InterfaceFilter is used to decide which interfaces mocks should be generated for.
 type InterfaceFilter interface {
@@ -85,8 +85,9 @@ func Parse(packageName string, directory string, filter InterfaceFilter) ([]Mock
 	var interfaces []MockedInterface
 
 	pkgs, err := packages.Load(&packages.Config{
-		Mode: packages.NeedName | packages.NeedTypes | packages.NeedImports | packages.NeedSyntax,
-		Dir:  directory,
+		Mode:  packages.NeedName | packages.NeedTypes | packages.NeedImports | packages.NeedSyntax,
+		Dir:   directory,
+		Tests: true,
 	}, "pattern="+packageName)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not load type information")


### PR DESCRIPTION
There were actually two issues:

- I wasn't asking `packages.Load` to consider tests, which prevented most of the example mocks from being generated.
- The package name passed in via GOPACKAGE doesn't contain the full package path, so it wasn't working properly. For now I've just adjusted it so you need to specify the full package name.