### PR TITLE
refactor: pull out import handling to separate type

### DIFF
--- a/parser/import_helper.go
+++ b/parser/import_helper.go
@@ -1,0 +1,109 @@
+package parser
+
+import (
+	"fmt"
+	"go/ast"
+	"go/types"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	kslices "github.com/adamconnelly/kelpie/slices"
+)
+
+type importHelper struct {
+	typesInfo             *types.Info
+	packageNamesToImports map[string]string
+	requiredImports       []string
+}
+
+func newImportHelper(typesInfo *types.Info, importSpecs []*ast.ImportSpec) *importHelper {
+	if typesInfo == nil {
+		panic("typesInfo cannot be nil")
+	}
+
+	packageNamesToImports := make(map[string]string, len(importSpecs))
+	for _, i := range importSpecs {
+		if i.Name != nil && i.Path.Value != "" {
+			packageName := i.Name.Name
+			if packageName == "." {
+				packageName = strings.Trim(i.Path.Value, `"`)
+			}
+
+			packageNamesToImports[packageName] = i.Name.Name + ` ` + i.Path.Value
+		} else if i.Name != nil {
+			packageNamesToImports[i.Name.Name] = `"` + i.Name.Name + `"`
+		} else if i.Path.Value != "" {
+			packageName := filepath.Base(strings.Trim(i.Path.Value, `"`))
+			packageNamesToImports[packageName] = i.Path.Value
+		}
+	}
+
+	return &importHelper{
+		typesInfo:             typesInfo,
+		packageNamesToImports: packageNamesToImports,
+	}
+}
+
+func (i *importHelper) AddImportsRequiredForType(e ast.Expr) {
+	for _, identifier := range i.getPackageIdentifiers(e) {
+		packageName := identifier.Name
+
+		// First let's check if the package name is in the import map. This handles standard
+		// expressions like `kelpie.Parser`.
+		if imp, ok := i.packageNamesToImports[packageName]; ok {
+			i.addImport(imp)
+			continue
+		}
+
+		// If we couldn't find it, the package might be implicit because of a dot import. We
+		// can use typesInfo.Uses to find the package for the identifier and look it up that way.
+		if use, ok := i.typesInfo.Uses[identifier]; ok {
+			pkg := use.Pkg()
+			if pkg == nil {
+				// If we found a usage but there's no package, it's a built-in type so no import
+				// is required. Just ignore and continue.
+				continue
+			}
+
+			if imp, ok := i.packageNamesToImports[pkg.Path()]; ok {
+				i.addImport(imp)
+				continue
+			}
+		}
+
+		panic(fmt.Sprintf("Could not find import statement for identifier %v. This is a bug in Kelpie!", identifier))
+	}
+}
+
+func (i *importHelper) RequiredImports() []string {
+	// Make sure the imports are sorted so that the code generation is stable.
+	slices.SortStableFunc(i.requiredImports, strings.Compare)
+
+	return i.requiredImports
+}
+
+func (i *importHelper) getPackageIdentifiers(e ast.Expr) []*ast.Ident {
+	identifiers := []*ast.Ident{}
+
+	switch n := e.(type) {
+	case *ast.Ident:
+		identifiers = append(identifiers, n)
+	case *ast.ArrayType:
+		identifiers = append(identifiers, i.getPackageIdentifiers(n.Elt)...)
+	case *ast.StarExpr:
+		identifiers = append(identifiers, i.getPackageIdentifiers(n.X)...)
+	case *ast.SelectorExpr:
+		identifiers = append(identifiers, i.getPackageIdentifiers(n.X)...)
+	default:
+		panic(fmt.Sprintf("Could not get package identifier from ast expression: %v. This is a bug in Kelpie!", e))
+	}
+
+	return identifiers
+}
+
+func (i *importHelper) addImport(imp string) {
+	if !kslices.Contains(i.requiredImports, func(i string) bool { return imp == i }) {
+		i.requiredImports = append(i.requiredImports, imp)
+	}
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -5,15 +5,12 @@ package parser
 import (
 	"fmt"
 	"go/ast"
-	"go/types"
-	"path/filepath"
-	"slices"
 	"strings"
 
 	"github.com/pkg/errors"
 	"golang.org/x/tools/go/packages"
 
-	kslices "github.com/adamconnelly/kelpie/slices"
+	"github.com/adamconnelly/kelpie/slices"
 )
 
 // MockedInterface represents an interface that a mock should be generated for.
@@ -29,14 +26,6 @@ type MockedInterface struct {
 
 	// Imports contains the list of imports required by the mocked interface.
 	Imports []string
-}
-
-func (m *MockedInterface) addImports(imports []string) {
-	for _, imp := range imports {
-		if !kslices.Contains(m.Imports, func(i string) bool { return imp == i }) {
-			m.Imports = append(m.Imports, imp)
-		}
-	}
 }
 
 // MethodDefinition defines a method in an interface.
@@ -89,14 +78,14 @@ type IncludingInterfaceFilter struct {
 
 // Include returns true if the specified interface should be mocked, false otherwise.
 func (f *IncludingInterfaceFilter) Include(name string) bool {
-	return kslices.Contains(f.InterfacesToInclude, func(n string) bool {
+	return slices.Contains(f.InterfacesToInclude, func(n string) bool {
 		return n == name
 	})
 }
 
 // Parse parses the source contained in the reader.
-func Parse(packageName string, directory string, filter InterfaceFilter) ([]*MockedInterface, error) {
-	var interfaces []*MockedInterface
+func Parse(packageName string, directory string, filter InterfaceFilter) ([]MockedInterface, error) {
+	var interfaces []MockedInterface
 
 	pkgs, err := packages.Load(&packages.Config{
 		Mode:  packages.NeedTypes | packages.NeedImports | packages.NeedSyntax | packages.NeedTypesInfo,
@@ -109,29 +98,13 @@ func Parse(packageName string, directory string, filter InterfaceFilter) ([]*Moc
 
 	for _, p := range pkgs {
 		for _, fileNode := range p.Syntax {
-			packageNamesToImports := make(map[string]string, len(fileNode.Imports))
-			for _, i := range fileNode.Imports {
-				if i.Name != nil && i.Path.Value != "" {
-					packageName := i.Name.Name
-					if packageName == "." {
-						packageName = strings.Trim(i.Path.Value, `"`)
-					}
-
-					packageNamesToImports[packageName] = i.Name.Name + ` ` + i.Path.Value
-				} else if i.Name != nil {
-					packageNamesToImports[i.Name.Name] = `"` + i.Name.Name + `"`
-				} else if i.Path.Value != "" {
-					packageName := filepath.Base(strings.Trim(i.Path.Value, `"`))
-					packageNamesToImports[packageName] = i.Path.Value
-				}
-			}
-
 			ast.Inspect(fileNode, func(n ast.Node) bool {
 				if t, ok := n.(*ast.TypeSpec); ok {
 					if t.Name.IsExported() {
 						if typeSpecType, ok := t.Type.(*ast.InterfaceType); ok {
 							if filter.Include(t.Name.Name) {
-								mockedInterface := &MockedInterface{
+								importHelper := newImportHelper(p.TypesInfo, fileNode.Imports)
+								mockedInterface := MockedInterface{
 									Name:        t.Name.Name,
 									PackageName: strings.ToLower(t.Name.Name),
 								}
@@ -153,7 +126,7 @@ func Parse(packageName string, directory string, filter InterfaceFilter) ([]*Moc
 											})
 										}
 
-										mockedInterface.addImports(getRequiredImports(param.Type, packageNamesToImports, p.TypesInfo))
+										importHelper.AddImportsRequiredForType(param.Type)
 									}
 
 									if funcType.Results != nil {
@@ -171,14 +144,14 @@ func Parse(packageName string, directory string, filter InterfaceFilter) ([]*Moc
 												})
 											}
 
-											mockedInterface.addImports(getRequiredImports(result.Type, packageNamesToImports, p.TypesInfo))
+											importHelper.AddImportsRequiredForType(result.Type)
 										}
 									}
 
 									mockedInterface.Methods = append(mockedInterface.Methods, methodDefinition)
 								}
 
-								slices.SortStableFunc(mockedInterface.Imports, strings.Compare)
+								mockedInterface.Imports = importHelper.RequiredImports()
 
 								interfaces = append(interfaces, mockedInterface)
 							}
@@ -209,57 +182,4 @@ func getTypeName(e ast.Expr) string {
 	}
 
 	panic(fmt.Sprintf("Unknown type %v. This is a bug in Kelpie!", e))
-}
-
-func getPackageIdentifiers(e ast.Expr) []*ast.Ident {
-	identifiers := []*ast.Ident{}
-
-	switch n := e.(type) {
-	case *ast.Ident:
-		identifiers = append(identifiers, n)
-	case *ast.ArrayType:
-		identifiers = append(identifiers, getPackageIdentifiers(n.Elt)...)
-	case *ast.StarExpr:
-		identifiers = append(identifiers, getPackageIdentifiers(n.X)...)
-	case *ast.SelectorExpr:
-		identifiers = append(identifiers, getPackageIdentifiers(n.X)...)
-	default:
-		panic(fmt.Sprintf("Could not get package identifier from ast expression: %v. This is a bug in Kelpie!", e))
-	}
-
-	return identifiers
-}
-
-func getRequiredImports(e ast.Expr, packageNamesToImports map[string]string, typesInfo *types.Info) []string {
-	requiredImports := []string{}
-	for _, identifier := range getPackageIdentifiers(e) {
-		packageName := identifier.Name
-
-		// First let's check if the package name is in the import map. This handles standard
-		// expressions like `kelpie.Parser`.
-		if i, ok := packageNamesToImports[packageName]; ok {
-			requiredImports = append(requiredImports, i)
-			continue
-		}
-
-		// If we couldn't find it, the package might be implicit because of a dot import. We
-		// can use typesInfo.Uses to find the package for the identifier and look it up that way.
-		if use, ok := typesInfo.Uses[identifier]; ok {
-			pkg := use.Pkg()
-			if pkg == nil {
-				// If we found a usage but there's no package, it's a built-in type so no import
-				// is required. Just ignore and continue.
-				continue
-			}
-
-			if i, ok := packageNamesToImports[pkg.Path()]; ok {
-				requiredImports = append(requiredImports, i)
-				continue
-			}
-		}
-
-		panic(fmt.Sprintf("Could not find import statement for identifier %v. This is a bug in Kelpie!", identifier))
-	}
-
-	return requiredImports
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -85,7 +85,7 @@ type NotificationService interface {
 	t.NoError(err)
 	t.Len(result, 1)
 
-	notificationService := slices.FirstOrPanic(result, func(mock *parser.MockedInterface) bool {
+	notificationService := slices.FirstOrPanic(result, func(mock parser.MockedInterface) bool {
 		return mock.Name == "NotificationService"
 	})
 	t.Equal("notificationservice", notificationService.PackageName)
@@ -135,7 +135,7 @@ type NotificationService interface {
 	t.NoError(err)
 	t.Len(result, 1)
 
-	notificationService := slices.FirstOrPanic(result, func(mock *parser.MockedInterface) bool {
+	notificationService := slices.FirstOrPanic(result, func(mock parser.MockedInterface) bool {
 		return mock.Name == "NotificationService"
 	})
 	t.Equal("notificationservice", notificationService.PackageName)
@@ -167,7 +167,7 @@ type AlarmService interface {
 	t.NoError(err)
 	t.Len(result, 1)
 
-	alarmService := slices.FirstOrPanic(result, func(mock *parser.MockedInterface) bool {
+	alarmService := slices.FirstOrPanic(result, func(mock parser.MockedInterface) bool {
 		return mock.Name == "AlarmService"
 	})
 	t.Equal("alarmservice", alarmService.PackageName)
@@ -201,7 +201,7 @@ type AlarmService interface {
 	t.NoError(err)
 	t.Len(result, 1)
 
-	alarmService := slices.FirstOrPanic(result, func(mock *parser.MockedInterface) bool {
+	alarmService := slices.FirstOrPanic(result, func(mock parser.MockedInterface) bool {
 		return mock.Name == "AlarmService"
 	})
 
@@ -328,7 +328,7 @@ type Requester interface {
 // TODO: add a test for types from the same package as the mock
 // TODO: what about empty interfaces? Return a warning?
 
-func (t *ParserTests) ParseInput(packageName, input string, filter parser.InterfaceFilter) ([]*parser.MockedInterface, error) {
+func (t *ParserTests) ParseInput(packageName, input string, filter parser.InterfaceFilter) ([]parser.MockedInterface, error) {
 	tmpDir, err := os.MkdirTemp("", "kelpie-parser-tests")
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create temp dir for module")


### PR DESCRIPTION
I've created an importHelper type to handle figuring out what imports are required. Partly this is to simplify the parser code, but it's also in preparation for supporting types from the mocked package.