### PR TITLE
feat: add support for maps

### DIFF
--- a/examples/mocks/accountservice/accountservice.go
+++ b/examples/mocks/accountservice/accountservice.go
@@ -81,6 +81,26 @@ func (m *Instance) DisabledAccountIDs() (r0 []uint) {
 	return
 }
 
+func (m *Instance) DisableReasons() (r0 map[uint]string) {
+	expectation := m.mock.Call("DisableReasons")
+	if expectation != nil {
+		if expectation.ObserveFn != nil {
+			observe := expectation.ObserveFn.(func() map[uint]string)
+			return observe()
+		}
+
+		if expectation.PanicArg != nil {
+			panic(expectation.PanicArg)
+		}
+
+		if expectation.Returns[0] != nil {
+			r0 = expectation.Returns[0].(map[uint]string)
+		}
+	}
+
+	return
+}
+
 func (m *Mock) Instance() *Instance {
 	return &m.instance
 }
@@ -419,5 +439,120 @@ type DisabledAccountIDsAction struct {
 }
 
 func (a *DisabledAccountIDsAction) CreateExpectation() *mocking.Expectation {
+	return &a.expectation
+}
+
+type DisableReasonsMethodMatcher struct {
+	matcher mocking.MethodMatcher
+}
+
+func (m *DisableReasonsMethodMatcher) CreateMethodMatcher() *mocking.MethodMatcher {
+	return &m.matcher
+}
+
+func DisableReasons() *DisableReasonsMethodMatcher {
+	result := DisableReasonsMethodMatcher{
+		matcher: mocking.MethodMatcher{
+			MethodName:       "DisableReasons",
+			ArgumentMatchers: make([]mocking.ArgumentMatcher, 0),
+		},
+	}
+
+	return &result
+}
+
+type DisableReasonsTimes struct {
+	matcher *DisableReasonsMethodMatcher
+}
+
+// Times allows you to restrict the number of times a particular expectation can be matched.
+func (m *DisableReasonsMethodMatcher) Times(times uint) *DisableReasonsTimes {
+	m.matcher.Times = &times
+
+	return &DisableReasonsTimes{
+		matcher: m,
+	}
+}
+
+// Once specifies that the expectation will only match once.
+func (m *DisableReasonsMethodMatcher) Once() *DisableReasonsTimes {
+	return m.Times(1)
+}
+
+// Never specifies that the method has not been called. This is mainly useful for verification
+// rather than mocking.
+func (m *DisableReasonsMethodMatcher) Never() *DisableReasonsTimes {
+	return m.Times(0)
+}
+
+// Return returns the specified results when the method is called.
+func (t *DisableReasonsTimes) Return(r0 map[uint]string) *DisableReasonsAction {
+	return &DisableReasonsAction{
+		expectation: mocking.Expectation{
+			MethodMatcher: &t.matcher.matcher,
+			Returns:       []any{r0},
+		},
+	}
+}
+
+// Panic panics using the specified argument when the method is called.
+func (t *DisableReasonsTimes) Panic(arg any) *DisableReasonsAction {
+	return &DisableReasonsAction{
+		expectation: mocking.Expectation{
+			MethodMatcher: &t.matcher.matcher,
+			PanicArg:      arg,
+		},
+	}
+}
+
+// When calls the specified observe callback when the method is called.
+func (t *DisableReasonsTimes) When(observe func() map[uint]string) *DisableReasonsAction {
+	return &DisableReasonsAction{
+		expectation: mocking.Expectation{
+			MethodMatcher: &t.matcher.matcher,
+			ObserveFn:     observe,
+		},
+	}
+}
+
+func (t *DisableReasonsTimes) CreateMethodMatcher() *mocking.MethodMatcher {
+	return &t.matcher.matcher
+}
+
+// Return returns the specified results when the method is called.
+func (m *DisableReasonsMethodMatcher) Return(r0 map[uint]string) *DisableReasonsAction {
+	return &DisableReasonsAction{
+		expectation: mocking.Expectation{
+			MethodMatcher: &m.matcher,
+			Returns:       []any{r0},
+		},
+	}
+}
+
+// Panic panics using the specified argument when the method is called.
+func (m *DisableReasonsMethodMatcher) Panic(arg any) *DisableReasonsAction {
+	return &DisableReasonsAction{
+		expectation: mocking.Expectation{
+			MethodMatcher: &m.matcher,
+			PanicArg:      arg,
+		},
+	}
+}
+
+// When calls the specified observe callback when the method is called.
+func (m *DisableReasonsMethodMatcher) When(observe func() map[uint]string) *DisableReasonsAction {
+	return &DisableReasonsAction{
+		expectation: mocking.Expectation{
+			MethodMatcher: &m.matcher,
+			ObserveFn:     observe,
+		},
+	}
+}
+
+type DisableReasonsAction struct {
+	expectation mocking.Expectation
+}
+
+func (a *DisableReasonsAction) CreateExpectation() *mocking.Expectation {
 	return &a.expectation
 }

--- a/examples/mocks/sender/sender.go
+++ b/examples/mocks/sender/sender.go
@@ -44,6 +44,26 @@ func (m *Instance) SendMessage(title *string, message string) (r0 error) {
 	return
 }
 
+func (m *Instance) SendMany(details map[string]string) (r0 error) {
+	expectation := m.mock.Call("SendMany", details)
+	if expectation != nil {
+		if expectation.ObserveFn != nil {
+			observe := expectation.ObserveFn.(func(details map[string]string) error)
+			return observe(details)
+		}
+
+		if expectation.PanicArg != nil {
+			panic(expectation.PanicArg)
+		}
+
+		if expectation.Returns[0] != nil {
+			r0 = expectation.Returns[0].(error)
+		}
+	}
+
+	return
+}
+
 func (m *Mock) Instance() *Instance {
 	return &m.instance
 }
@@ -172,5 +192,126 @@ type SendMessageAction struct {
 }
 
 func (a *SendMessageAction) CreateExpectation() *mocking.Expectation {
+	return &a.expectation
+}
+
+type SendManyMethodMatcher struct {
+	matcher mocking.MethodMatcher
+}
+
+func (m *SendManyMethodMatcher) CreateMethodMatcher() *mocking.MethodMatcher {
+	return &m.matcher
+}
+
+func SendMany[P0 map[string]string | mocking.Matcher[map[string]string]](details P0) *SendManyMethodMatcher {
+	result := SendManyMethodMatcher{
+		matcher: mocking.MethodMatcher{
+			MethodName:       "SendMany",
+			ArgumentMatchers: make([]mocking.ArgumentMatcher, 1),
+		},
+	}
+
+	if matcher, ok := any(details).(mocking.Matcher[map[string]string]); ok {
+		result.matcher.ArgumentMatchers[0] = matcher
+	} else {
+		result.matcher.ArgumentMatchers[0] = kelpie.ExactMatch(any(details).(map[string]string))
+	}
+
+	return &result
+}
+
+type SendManyTimes struct {
+	matcher *SendManyMethodMatcher
+}
+
+// Times allows you to restrict the number of times a particular expectation can be matched.
+func (m *SendManyMethodMatcher) Times(times uint) *SendManyTimes {
+	m.matcher.Times = &times
+
+	return &SendManyTimes{
+		matcher: m,
+	}
+}
+
+// Once specifies that the expectation will only match once.
+func (m *SendManyMethodMatcher) Once() *SendManyTimes {
+	return m.Times(1)
+}
+
+// Never specifies that the method has not been called. This is mainly useful for verification
+// rather than mocking.
+func (m *SendManyMethodMatcher) Never() *SendManyTimes {
+	return m.Times(0)
+}
+
+// Return returns the specified results when the method is called.
+func (t *SendManyTimes) Return(r0 error) *SendManyAction {
+	return &SendManyAction{
+		expectation: mocking.Expectation{
+			MethodMatcher: &t.matcher.matcher,
+			Returns:       []any{r0},
+		},
+	}
+}
+
+// Panic panics using the specified argument when the method is called.
+func (t *SendManyTimes) Panic(arg any) *SendManyAction {
+	return &SendManyAction{
+		expectation: mocking.Expectation{
+			MethodMatcher: &t.matcher.matcher,
+			PanicArg:      arg,
+		},
+	}
+}
+
+// When calls the specified observe callback when the method is called.
+func (t *SendManyTimes) When(observe func(details map[string]string) error) *SendManyAction {
+	return &SendManyAction{
+		expectation: mocking.Expectation{
+			MethodMatcher: &t.matcher.matcher,
+			ObserveFn:     observe,
+		},
+	}
+}
+
+func (t *SendManyTimes) CreateMethodMatcher() *mocking.MethodMatcher {
+	return &t.matcher.matcher
+}
+
+// Return returns the specified results when the method is called.
+func (m *SendManyMethodMatcher) Return(r0 error) *SendManyAction {
+	return &SendManyAction{
+		expectation: mocking.Expectation{
+			MethodMatcher: &m.matcher,
+			Returns:       []any{r0},
+		},
+	}
+}
+
+// Panic panics using the specified argument when the method is called.
+func (m *SendManyMethodMatcher) Panic(arg any) *SendManyAction {
+	return &SendManyAction{
+		expectation: mocking.Expectation{
+			MethodMatcher: &m.matcher,
+			PanicArg:      arg,
+		},
+	}
+}
+
+// When calls the specified observe callback when the method is called.
+func (m *SendManyMethodMatcher) When(observe func(details map[string]string) error) *SendManyAction {
+	return &SendManyAction{
+		expectation: mocking.Expectation{
+			MethodMatcher: &m.matcher,
+			ObserveFn:     observe,
+		},
+	}
+}
+
+type SendManyAction struct {
+	expectation mocking.Expectation
+}
+
+func (a *SendManyAction) CreateExpectation() *mocking.Expectation {
 	return &a.expectation
 }

--- a/examples/result_test.go
+++ b/examples/result_test.go
@@ -13,6 +13,7 @@ type AccountService interface {
 	SendActivationEmail(emailAddress string) bool
 	DisableAccount(id uint)
 	DisabledAccountIDs() []uint
+	DisableReasons() map[uint]string
 }
 
 type ResultTests struct {
@@ -81,6 +82,20 @@ func (t *ResultTests) Test_CanMockMethodsWithNoArgs() {
 
 	// Assert
 	t.Equal([]uint{1, 2, 3}, result)
+}
+
+func (t *ResultTests) Test_CanReturnMaps() {
+	// Arrange
+	mock := accountservice.NewMock()
+	mock.Setup(accountservice.DisableReasons().Return(map[uint]string{1: "Breached usage policy", 3: "Doesn't like unicorns"}))
+
+	// Act
+	result := mock.Instance().DisableReasons()
+
+	// Assert
+	t.Len(result, 2)
+	t.Equal("Breached usage policy", result[1])
+	t.Equal("Doesn't like unicorns", result[3])
 }
 
 func TestResults(t *testing.T) {

--- a/kelpie.go
+++ b/kelpie.go
@@ -1,19 +1,25 @@
 // Package kelpie contains helpers for matching arguments when configuring a mock.
 package kelpie
 
-import "github.com/adamconnelly/kelpie/mocking"
+import (
+	"reflect"
+
+	"github.com/adamconnelly/kelpie/mocking"
+)
 
 // ExactMatch matches parameters to the value of exactMatch.
-func ExactMatch[T comparable](exactMatch T) mocking.Matcher[T] {
-	return Match(func(arg T) bool { return arg == exactMatch })
+func ExactMatch[T any](exactMatch T) mocking.Matcher[T] {
+	return Match(func(arg T) bool {
+		return reflect.DeepEqual(arg, exactMatch)
+	})
 }
 
 // Any matches any value of T.
-func Any[T comparable]() mocking.Matcher[T] {
+func Any[T any]() mocking.Matcher[T] {
 	return Match(func(arg T) bool { return true })
 }
 
 // Match uses isMatch to determine whether an argument matches.
-func Match[T comparable](isMatch func(arg T) bool) mocking.Matcher[T] {
+func Match[T any](isMatch func(arg T) bool) mocking.Matcher[T] {
 	return mocking.Matcher[T]{MatchFn: isMatch}
 }

--- a/mocking/matcher.go
+++ b/mocking/matcher.go
@@ -7,7 +7,7 @@ type ArgumentMatcher interface {
 }
 
 // Matcher is used to match an argument in a method invocation.
-type Matcher[T comparable] struct {
+type Matcher[T any] struct {
 	MatchFn func(input T) bool
 }
 

--- a/parser/import_helper.go
+++ b/parser/import_helper.go
@@ -95,6 +95,9 @@ func (i *importHelper) getPackageIdentifiers(e ast.Expr) []*ast.Ident {
 		identifiers = append(identifiers, i.getPackageIdentifiers(n.X)...)
 	case *ast.SelectorExpr:
 		identifiers = append(identifiers, i.getPackageIdentifiers(n.X)...)
+	case *ast.MapType:
+		identifiers = append(identifiers, i.getPackageIdentifiers(n.Key)...)
+		identifiers = append(identifiers, i.getPackageIdentifiers(n.Value)...)
 	default:
 		panic(fmt.Sprintf("Could not get package identifier from ast expression: %v. This is a bug in Kelpie!", e))
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -179,6 +179,11 @@ func getTypeName(e ast.Expr) string {
 		packageName := getTypeName(n.X)
 
 		return packageName + "." + n.Sel.Name
+	case *ast.MapType:
+		keyType := getTypeName(n.Key)
+		valueType := getTypeName(n.Value)
+
+		return "map[" + keyType + "]" + valueType
 	}
 
 	panic(fmt.Sprintf("Unknown type %v. This is a bug in Kelpie!", e))


### PR DESCRIPTION
- Added support for maps used as both parameters or return results.
- I had to alter `kelpie.ExactMatch()` to use `reflect.DeepEqual()` instead of just `==`. The reason is that maps aren't `comparable`.