### PR TITLE
feat: add newline between import groups

### DIFF
--- a/cmd/kelpie/mock.go.tmpl
+++ b/cmd/kelpie/mock.go.tmpl
@@ -48,9 +48,11 @@ package {{ .PackageName }}
 import (
 	"github.com/adamconnelly/kelpie"
 	"github.com/adamconnelly/kelpie/mocking"
-	{{- range $i := .Imports }}
+{{- with .Imports }}
+{{ range $i := . }}
 	{{ $i }}
 	{{- end }}
+{{- end }}
 )
 
 type Mock struct {

--- a/examples/mocks/requester/requester.go
+++ b/examples/mocks/requester/requester.go
@@ -4,6 +4,7 @@ package requester
 import (
 	"github.com/adamconnelly/kelpie"
 	"github.com/adamconnelly/kelpie/mocking"
+
 	"io"
 	. "net/http"
 )

--- a/examples/users/mocks/userrepository/userrepository.go
+++ b/examples/users/mocks/userrepository/userrepository.go
@@ -4,6 +4,7 @@ package userrepository
 import (
 	"github.com/adamconnelly/kelpie"
 	"github.com/adamconnelly/kelpie/mocking"
+
 	"github.com/adamconnelly/kelpie/examples/users"
 )
 


### PR DESCRIPTION
I've adjusted the template to add a newline between the Kelpie imports and the imports required by the mock to make it easier to understand where they come from when reading the generated code.