### PR TITLE
feat: improve matching empty variadic argument lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,8 @@ func (t *VariadicFunctionsTests) Test_Parameters_ExactMatch() {
 }
 ```
 
+#### Mixing exact and custom matching
+
 Because of the way generics work, you can't mix exact matching with custom matching. So for example the following will work:
 
 ```go
@@ -242,6 +244,8 @@ mock.Setup(printer.Printf("Hello %s. This is %s, %s.", "Dolly", kelpie.Any[strin
 		Return("Hello Dolly. This is Louis, Dolly."))
 ```
 
+#### Mixing argument types
+
 If your variadic parameter is `...any` or `...interface{}`, and you try to pass in multiple different types of argument, the Go compiler can't infer the types for you. Here's an example:
 
 ```go
@@ -253,6 +257,30 @@ To fix this, just specify the type parameters:
 
 ```go
 mock.Called(printer.Printf[string, any]("Hello world!", "One", 2, 3.0))
+```
+
+#### Matching no arguments
+
+If you want to match that a variadic function call is made with no arguments provided, you can use `kelpie.None[T]()`:
+
+```go
+mock.Setup(printer.Printf("Hello world", kelpie.None[any]()))
+mock.Called(secrets.Get(kelpie.Any[context.Context](), kelpie.Any[string](), kelpie.None[any]()))
+```
+
+The reason for using `None` is that otherwise the Go compiler can't infer the type of the variadic parameter:
+
+```go
+// Fails with "cannot infer P1"
+mock.Setup(printer.Printf("Nothing to say").Return("Nothing to say"))
+```
+
+Another option instead of using `None` is to specify the type arguments explicitly, but that can become very verbose, especially when using Kelpie's matching functions:
+
+```go
+secretsManagerMock.Called(
+	secretsmanagerapi.PutSecretValue[mocking.Matcher[context.Context], mocking.Matcher[*secretsmanager.PutSecretValueInput], func(*secretsmanager.Options)](
+		kelpie.Any[context.Context](), kelpie.Any[*secretsmanager.PutSecretValueInput]()))
 ```
 
 ### Interface parameters

--- a/examples/variadic_functions_test.go
+++ b/examples/variadic_functions_test.go
@@ -48,6 +48,25 @@ func (t *VariadicFunctionsTests) Test_Parameters_AnyMatch() {
 	t.Equal("Hello Dolly. This is Louis, Dolly.", result)
 }
 
+func (t *VariadicFunctionsTests) Test_Parameters_NoneProvided() {
+	// Arrange
+	mock := printer.NewMock()
+
+	mock.Setup(printer.Printf("Nothing to say", kelpie.None[any]()).
+		Return("Nothing to say"))
+
+	// Act
+	result1 := mock.Instance().Printf("Nothing to say")
+	result2 := mock.Instance().Printf("Who are %s", "you")
+
+	// Assert
+	t.Equal("Nothing to say", result1)
+	t.Equal("", result2)
+	t.True(mock.Called(printer.Printf("Nothing to say", kelpie.None[any]())))
+	t.True(mock.Called(printer.Printf(kelpie.Any[string](), kelpie.None[any]())))
+	t.False(mock.Called(printer.Printf("Testing %d %d %d", 1, 2, 3)))
+}
+
 func (t *VariadicFunctionsTests) Test_Parameters_When() {
 	// Arrange
 	mock := printer.NewMock()

--- a/kelpie.go
+++ b/kelpie.go
@@ -23,3 +23,9 @@ func Any[T any]() mocking.Matcher[T] {
 func Match[T any](isMatch func(arg T) bool) mocking.Matcher[T] {
 	return mocking.Matcher[T]{MatchFn: isMatch}
 }
+
+// None is used when mocking methods that contain a variable parameter list to indicate that
+// no parameters should be provided, for example: printMock.Setup(print.Printf("Testing 123", kelpie.None[any]())).
+func None[T any]() mocking.Matcher[T] {
+	return mocking.None[T]()
+}

--- a/mocking/matcher_test.go
+++ b/mocking/matcher_test.go
@@ -35,6 +35,16 @@ func (t *MatcherTests) Test_VariadicMatcher_MatchesWhenParametersEmpty() {
 			inputs:   []any{},
 			isMatch:  true,
 		},
+		"None matcher matches empty input": {
+			matchers: []mocking.ArgumentMatcher{mocking.None[any]()},
+			inputs:   []any{},
+			isMatch:  true,
+		},
+		"None matcher does not match non-empty input": {
+			matchers: []mocking.ArgumentMatcher{mocking.None[any]()},
+			inputs:   []any{"testing"},
+			isMatch:  false,
+		},
 		"Matchers empty but arguments provided": {
 			matchers: []mocking.ArgumentMatcher{},
 			inputs:   []any{"testing", 1, 2, 3},


### PR DESCRIPTION
Expecting or verifying that a variadic method was called with no arguments passed was difficult because by not passing any arguments, it prevented the Go compiler from being able to infer the types. I've added a new `kelpie.None[T]()` helper to make this easier.