### PR TITLE
feat: allow matching on any number of variadic args

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,14 @@ secretsManagerMock.Called(
 		kelpie.Any[context.Context](), kelpie.Any[*secretsmanager.PutSecretValueInput]()))
 ```
 
+#### Matching any arguments
+
+Similar to the way that you can match against no parameters with `kelpie.None[T]()`, you can match that any amount of parameters are passed to a variadic function using `kelpie.AnyArgs[T]()`:
+
+```go
+mock.Setup(printer.Printf("Don't panic!", kelpie.AnyArgs[any]()).Panic("Ok!"))
+```
+
 ### Interface parameters
 
 Under the hood, Kelpie uses Go generics to allow either the actual parameter type or a Kelpie matcher to be passed in when setting up mocks or verifying expectations. For example, say we have the following method:

--- a/examples/variadic_functions_test.go
+++ b/examples/variadic_functions_test.go
@@ -67,6 +67,25 @@ func (t *VariadicFunctionsTests) Test_Parameters_NoneProvided() {
 	t.False(mock.Called(printer.Printf("Testing %d %d %d", 1, 2, 3)))
 }
 
+func (t *VariadicFunctionsTests) Test_Parameters_AnyMatchingWithArgumentList() {
+	// Arrange
+	mock := printer.NewMock()
+
+	mock.Setup(printer.Printf("Nothing to say", kelpie.AnyArgs[any]()).
+		Return("Nothing to say"))
+
+	// Act
+	result1 := mock.Instance().Printf("Nothing to say")
+	result2 := mock.Instance().Printf("Nothing to say", 1)
+	result3 := mock.Instance().Printf("Nothing to say", 1, "two", 3)
+
+	// Assert
+	t.Equal("Nothing to say", result1)
+	t.Equal("Nothing to say", result2)
+	t.Equal("Nothing to say", result3)
+	t.True(mock.Called(printer.Printf("Nothing to say", kelpie.AnyArgs[any]())))
+}
+
 func (t *VariadicFunctionsTests) Test_Parameters_When() {
 	// Arrange
 	mock := printer.NewMock()

--- a/kelpie.go
+++ b/kelpie.go
@@ -25,7 +25,17 @@ func Match[T any](isMatch func(arg T) bool) mocking.Matcher[T] {
 }
 
 // None is used when mocking methods that contain a variable parameter list to indicate that
-// no parameters should be provided, for example: printMock.Setup(print.Printf("Testing 123", kelpie.None[any]())).
+// no parameters should be provided.
+//
+// For example: printMock.Setup(print.Printf("Testing 123", kelpie.None[any]())).
 func None[T any]() mocking.Matcher[T] {
 	return mocking.None[T]()
+}
+
+// AnyArgs is used when mocking methods that contain a variable parameter list when you don't
+// care what arguments are passed as the variable parameter. For example:
+//
+// printMock.Setup(print.Printf("Testing 123", kelpie.AnyArgs[any]()).Panic("Oh no!"))
+func AnyArgs[T any]() mocking.Matcher[T] {
+	return mocking.AnyArgs[T]()
 }

--- a/mocking/matcher_test.go
+++ b/mocking/matcher_test.go
@@ -45,6 +45,16 @@ func (t *MatcherTests) Test_VariadicMatcher_MatchesWhenParametersEmpty() {
 			inputs:   []any{"testing"},
 			isMatch:  false,
 		},
+		"Any args matcher matches empty input": {
+			matchers: []mocking.ArgumentMatcher{mocking.AnyArgs[any]()},
+			inputs:   []any{},
+			isMatch:  true,
+		},
+		"Any args matcher matches non-empty input": {
+			matchers: []mocking.ArgumentMatcher{mocking.AnyArgs[any]()},
+			inputs:   []any{"testing"},
+			isMatch:  true,
+		},
 		"Matchers empty but arguments provided": {
 			matchers: []mocking.ArgumentMatcher{},
 			inputs:   []any{"testing", 1, 2, 3},


### PR DESCRIPTION
I've added a new `kelpie.AnyArgs[T]()` for working with variadic methods. It can be used where we really don't care if any args are passed to the method.