### PR TITLE
fix: duplicate interfaces being generated

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ At the moment Kelpie is very much in development, and there are missing features
 
 The following is a list of known-outstanding features and known issues:
 
-- [ ] For some reason Kelpie is generating multiple mocks when specifying built-in interfaces. See the [Mock Generation](#mock-generation) section for an example.
+- [ ] Add support for embedded interfaces.
 
 ## Quickstart
 
@@ -95,7 +95,6 @@ $ kelpie generate
 Kelpie mock generation starting - preparing to add some magic to your code-base!
 
 Parsing package 'io' for interfaces to mock.
-  - Generating a mock for 'Reader'.
   - Generating a mock for 'Reader'.
 
 Parsing package 'github.com/adamconnelly/kelpie/examples' for interfaces to mock.

--- a/examples/external_types_test.go
+++ b/examples/external_types_test.go
@@ -3,9 +3,10 @@ package examples
 import (
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/adamconnelly/kelpie"
 	"github.com/adamconnelly/kelpie/examples/mocks/reader"
-	"github.com/stretchr/testify/suite"
 )
 
 type ExternalTypesTests struct {

--- a/maps/maps.go
+++ b/maps/maps.go
@@ -12,3 +12,15 @@ func Keys[TKey comparable, TValue any](m map[TKey]TValue) []TKey {
 
 	return keys
 }
+
+// Values returns the values in the map.
+func Values[TKey comparable, TValue any](m map[TKey]TValue) []TValue {
+	values := make([]TValue, len(m))
+	index := 0
+	for _, v := range m {
+		values[index] = v
+		index++
+	}
+
+	return values
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -689,6 +689,21 @@ type DoubleNested struct {
 	t.Len(DoSomethingElse.Results, 2)
 }
 
+func (t *ParserTests) Test_Parse_CanParseStdlibInterfaces() {
+	// Arrange
+	t.interfaceFilter.Setup(interfacefilter.Include(kelpie.Any[string]()).Return(false))
+	t.interfaceFilter.Setup(interfacefilter.Include("Reader").Return(true))
+
+	// Act
+	result, err := parser.Parse("io", ".", t.interfaceFilter.Instance())
+
+	// Assert
+	t.NoError(err)
+	t.Len(result.Mocks, 1)
+	t.Len(result.Mocks[0].Methods, 1)
+	t.Equal("Read", result.Mocks[0].Methods[0].Name)
+}
+
 func (t *ParserTests) Test_MockedInterface_AnyMethodsHaveParameters_ReturnsFalseIfNoMethodsHaveParameters() {
 	// Arrange
 	mockedInterface := parser.MockedInterface{


### PR DESCRIPTION
The problem is because I'm passing the `Tests: true` config option to `packages.Load`, multiple packages can be returned for a single package ID. For now I've just taken the easy option of using a map to ensure that there's no duplicates.